### PR TITLE
Update to allow existing users in session auth

### DIFF
--- a/nuxt-app/composables/usePartySession.ts
+++ b/nuxt-app/composables/usePartySession.ts
@@ -26,7 +26,11 @@ export default function (username: string, userId: string) {
     addMessage: (msg: string) =>
       $client.session.addMessage.mutate({
         message: {
-          member: { id: partySessionHelper.me.value?.id ?? '', name: username },
+          member: {
+            id: partySessionHelper.me.value?.id ?? '',
+            name: username,
+            isHost: partySessionHelper.me.value?.isHost ?? false,
+          },
           content: msg,
         },
         session: {

--- a/nuxt-app/composables/usePartySession.ts
+++ b/nuxt-app/composables/usePartySession.ts
@@ -15,7 +15,10 @@ export default function () {
   const code = route.query.code?.toString()
 
   // TODO: Get username from query parameters or local storage?
+  // (If reading from local storage everything should be done in the `if (!process.server)` block)
   const username = `user ${genNanoId()}`
+  // Optional userIf (used if loading existing user)
+  const userId = genNanoId()
 
   if (!code) throw new Error('Party code is required in query parameters')
 
@@ -42,7 +45,7 @@ export default function () {
   // Client-side only
   if (!process.server) {
     // Initialize Pusher client and subscribe to the party session channel
-    const partySession = new PartySession(code, username)
+    const partySession = new PartySession(code, username, userId)
 
     // Get subscribed user for party session helper
     partySession.onSubscribed((me: Member) => {

--- a/nuxt-app/composables/usePartySession.ts
+++ b/nuxt-app/composables/usePartySession.ts
@@ -1,5 +1,4 @@
 import { Message, Member } from '~/types/partySession'
-import { genNanoId } from '~/utils/nanoId'
 import { PartySession } from '~/utils/partySession'
 
 /**
@@ -9,16 +8,10 @@ import { PartySession } from '~/utils/partySession'
  * - Provides method for adding new messages
  * - Provides refs to the party's users and messages
  */
-export default function () {
+export default function (username: string, userId: string) {
   // Get party code from page query parameters
   const route = useRoute()
   const code = route.query.code?.toString()
-
-  // TODO: Get username from query parameters or local storage?
-  // (If reading from local storage everything should be done in the `if (!process.server)` block)
-  const username = `user ${genNanoId()}`
-  // Optional userIf (used if loading existing user)
-  const userId = genNanoId()
 
   if (!code) throw new Error('Party code is required in query parameters')
 

--- a/nuxt-app/pages/session.vue
+++ b/nuxt-app/pages/session.vue
@@ -1,12 +1,24 @@
 <script setup lang="ts">
+  import { genNanoId } from '~/utils/nanoId'
+
   definePageMeta({
     layout: 'default-home',
   })
 
   const message = ref('')
 
+  // TODO: Get username from local storage:
+  // - If reading/writing from/to local storage everything should be done in a `if (process.client) {...}` block!
+  // - Local storage is untrusted data source -> validate content using zod
+  // - Maybe offload local-storage-logic (process-check & validation) into composable (resulting in : `const localStorageContent = useLocalStorage()`)
+  const username = `user ${genNanoId()}`
+  // Generate new userId (only used if no Id exists in local storage)
+  const userId = genNanoId()
+
   // Get the party helpers
-  const { me, messages, addMessage, members } = usePartySession()
+  const { me, messages, addMessage, members } = usePartySession(username, userId)
+
+  // TODO: Save user data (`me`) to local storage
 </script>
 
 <template>

--- a/nuxt-app/pages/session.vue
+++ b/nuxt-app/pages/session.vue
@@ -31,7 +31,7 @@
     <VRow>
       <VCol>
         <div>Current users:</div>
-        <div v-for="member in members" :key="member.id">{{ member.name }}</div>
+        <div v-for="member in members" :key="member.id">{{ member.name }} {{ member.isHost ? 'HOST' : '' }}</div>
       </VCol>
     </VRow>
     <VRow>

--- a/nuxt-app/server/api/pusher_auth.post.ts
+++ b/nuxt-app/server/api/pusher_auth.post.ts
@@ -41,10 +41,11 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Get username from request query params
+  // Get username and optional user Id (for existing session members) from request query params
   // TODO: Only allow unique usernames?
   const query = getQuery(event)
-  const userName = query.name?.toString()
+  const userName = query.user_name?.toString()
+  const userId = query.user_id?.toString()
 
   if (!userName) {
     throw createError({
@@ -55,7 +56,7 @@ export default defineEventHandler(async (event) => {
 
   // Create user data
   const prescenceData: PresenceData = {
-    user_id: genNanoId(),
+    user_id: userId ?? genNanoId(),
     user_info: {
       userName,
     },

--- a/nuxt-app/server/api/pusher_auth.post.ts
+++ b/nuxt-app/server/api/pusher_auth.post.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { appRouter } from '../trpc/routers'
-import { genNanoId } from '~/utils/nanoId'
 import { partySessionConfig } from '~/utils/partySession'
 import { PartySession } from '~/server/utils/partySession'
 import { PresenceData } from '~/types/partySession'
@@ -54,9 +53,16 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  if (!userId) {
+    throw createError({
+      statusCode: 403, // use 403 for Pusher convention
+      message: 'No user Id provided',
+    })
+  }
+
   // Create user data
   const prescenceData: PresenceData = {
-    user_id: userId ?? genNanoId(),
+    user_id: userId,
     user_info: {
       userName,
     },

--- a/nuxt-app/server/trpc/context.ts
+++ b/nuxt-app/server/trpc/context.ts
@@ -1,7 +1,6 @@
 import { inferAsyncReturnType } from '@trpc/server'
 import type { H3Event } from 'h3'
-import { parse } from 'cookie'
-import { Credentials } from '../utils/pkce'
+import { getCredentials } from '../utils/credentials'
 
 /**
  * Create context for all incoming request
@@ -10,21 +9,8 @@ import { Credentials } from '../utils/pkce'
  * Reference: https://trpc-nuxt-docs.vercel.app/get-started/usage/recommended#1-create-a-trpc-router
  */
 export const createContext = (event: H3Event) => {
-  // Get cookie header from request
-  // Reference:
-  // https://trpc-nuxt.vercel.app/get-started/tips/authorization#create-context-from-request-headers
-  const rawCookies = getRequestHeader(event, 'cookie')
-  let credentials: Partial<Credentials> = {}
-  // Parse cookie string and extract credentials
-  if (rawCookies) {
-    const cookies = parse(rawCookies)
-    credentials = {
-      verifier: cookies.code_verifier,
-      accessToken: cookies.access_token,
-      refreshToken: cookies.refresh_token,
-    }
-  }
-
+  // Get credentials from request cookies
+  const credentials = getCredentials(event)
   return {
     // Pass credentials to tRPC context to be used in auth middleware
     credentials,

--- a/nuxt-app/server/utils/credentials.ts
+++ b/nuxt-app/server/utils/credentials.ts
@@ -1,0 +1,25 @@
+import type { H3Event } from 'h3'
+import { parse } from 'cookie'
+import { Credentials } from './pkce'
+
+/**
+ * Get credentials from cookie header.
+ *
+ * Reference:
+ * https://trpc-nuxt.vercel.app/get-started/tips/authorization#create-context-from-request-headers
+ */
+export const getCredentials = (event: H3Event) => {
+  const rawCookies = getRequestHeader(event, 'cookie')
+  let credentials: Partial<Credentials> = {}
+  // Parse cookie string and extract credentials
+  if (rawCookies) {
+    const cookies = parse(rawCookies)
+    credentials = {
+      verifier: cookies.code_verifier,
+      accessToken: cookies.access_token,
+      refreshToken: cookies.refresh_token,
+    }
+  }
+
+  return credentials
+}

--- a/nuxt-app/types/partySession.ts
+++ b/nuxt-app/types/partySession.ts
@@ -9,6 +9,7 @@ export const partyCodeSchema = nanoId(partyCodeLength, /^[A-Z0-9]+$/)
 export const memberSchema = z.object({
   id: nanoId(),
   name: z.string(),
+  isHost: z.boolean(),
 })
 
 export const messageSchema = z.object({
@@ -27,5 +28,5 @@ export type Message = z.infer<typeof messageSchema>
  */
 export type PresenceData = {
   user_id: string
-  user_info: { userName: string }
+  user_info: { userName: string; isHost: boolean }
 }

--- a/nuxt-app/utils/partySession.ts
+++ b/nuxt-app/utils/partySession.ts
@@ -13,8 +13,7 @@ export const partySessionConfig = {
     /** Custom events. */
     messages: 'messages',
   },
-  authEndpoint: (username: string, userId?: string) =>
-    `/api/pusher_auth?user_name=${username}` + (userId ? `&user_id=${userId}` : ''),
+  authEndpoint: (username: string, userId: string) => `/api/pusher_auth?user_name=${username}&user_id=${userId}`,
   presenceCacheChannelPrefix: 'presence-cache-',
   /** Create presence-cache channel using Pusher naming convention.
    *
@@ -47,7 +46,7 @@ type PusherMemberData = {
 export class PartySession {
   sessionCode: string
   username: string
-  userId?: string
+  userId: string
   pusher: Pusher
   partyChannel: Channel
 
@@ -56,7 +55,7 @@ export class PartySession {
    *
    * Validates session code and subscribes to the party session's Pusher channel.
    */
-  constructor(sessionCode: string, username: string, userId?: string) {
+  constructor(sessionCode: string, username: string, userId: string) {
     // Validate session code
     const uppercaseCode = partyCodeSchema.parse(sessionCode.toUpperCase())
     // Set the session code and username
@@ -90,7 +89,7 @@ export class PartySession {
   /** Get me property from channel members. */
   private getMe(): Member {
     const defaultMe = {
-      id: this.userId ?? '',
+      id: this.userId,
       name: this.username,
     }
     if ('members' in this.partyChannel && 'members' in (this.partyChannel.members as PusherMemberData)) {

--- a/nuxt-app/utils/partySession.ts
+++ b/nuxt-app/utils/partySession.ts
@@ -13,7 +13,8 @@ export const partySessionConfig = {
     /** Custom events. */
     messages: 'messages',
   },
-  authEndpoint: (username: string) => `/api/pusher_auth?name=${username}`,
+  authEndpoint: (username: string, userId?: string) =>
+    `/api/pusher_auth?user_name=${username}` + (userId ? `&user_id=${userId}` : ''),
   presenceCacheChannelPrefix: 'presence-cache-',
   /** Create presence-cache channel using Pusher naming convention.
    *
@@ -46,6 +47,7 @@ type PusherMemberData = {
 export class PartySession {
   sessionCode: string
   username: string
+  userId?: string
   pusher: Pusher
   partyChannel: Channel
 
@@ -54,12 +56,13 @@ export class PartySession {
    *
    * Validates session code and subscribes to the party session's Pusher channel.
    */
-  constructor(sessionCode: string, username: string) {
+  constructor(sessionCode: string, username: string, userId?: string) {
     // Validate session code
     const uppercaseCode = partyCodeSchema.parse(sessionCode.toUpperCase())
     // Set the session code and username
     this.sessionCode = uppercaseCode
     this.username = username
+    this.userId = userId
 
     // Initialize the pusher client
     // Reference: https://github.com/pusher/pusher-js#configuration
@@ -67,7 +70,7 @@ export class PartySession {
     this.pusher = new Pusher(publicVars.PUSHER_KEY, {
       cluster: publicVars.PUSHER_CLUSTER,
       channelAuthorization: {
-        endpoint: authEndpoint(username),
+        endpoint: authEndpoint(username, userId),
         transport: 'ajax',
       },
     })
@@ -87,7 +90,7 @@ export class PartySession {
   /** Get me property from channel members. */
   private getMe(): Member {
     const defaultMe = {
-      id: '',
+      id: this.userId ?? '',
       name: this.username,
     }
     if ('members' in this.partyChannel && 'members' in (this.partyChannel.members as PusherMemberData)) {

--- a/nuxt-app/utils/partySession.ts
+++ b/nuxt-app/utils/partySession.ts
@@ -91,6 +91,7 @@ export class PartySession {
     const defaultMe = {
       id: this.userId,
       name: this.username,
+      isHost: false,
     }
     if ('members' in this.partyChannel && 'members' in (this.partyChannel.members as PusherMemberData)) {
       const me = (this.partyChannel.members as PusherMemberData).me
@@ -98,6 +99,7 @@ export class PartySession {
       return {
         id: me.id,
         name: me.info.userName,
+        isHost: me.info.isHost,
       }
     } else {
       return defaultMe
@@ -117,6 +119,7 @@ export class PartySession {
       return Object.entries(members).map(([id, info]) => ({
         id,
         name: info.userName,
+        isHost: info.isHost,
       }))
     } else {
       return []


### PR DESCRIPTION
Ermöglicht es, existierende User im Pusher-"Auth" zu übergeben.

Möglicher Ablauf:

1. Session-User-Info auf Party-Basis in der entspechenden Page im Local Storage speichern `{userInfo: { "partyCode1": { "username": "xyz", "userId": "123" }, "partyCode2": { "username": "qwe", userId: "456" } } }`
~~2. User-Info für Party-Code in `/composables/usePartySession.ts` clienseitig aus Local Storage laden -> bei Instantiierung von `PartySession`-Helper übergeben~~