### PR TITLE
Add setup for Spotify-Web-API and update user authentication

### DIFF
--- a/nuxt-app/composables/useAppCookies.ts
+++ b/nuxt-app/composables/useAppCookies.ts
@@ -1,8 +1,7 @@
 /** Composable for accessing all relevant app cookie refs. */
 const useAppCookies = () => {
   return {
-    access_token: useCookie('access_token', defaultCredentialsCookieSerializationOpts),
-    refresh_token: useCookie('refresh_token', defaultCredentialsCookieSerializationOpts),
+    jwt: useCookie('jwt', defaultCredentialsCookieSerializationOpts),
     code_verifier: useCookie('code_verifier', { ...defaultCredentialsCookieSerializationOpts, httpOnly: false }),
   }
 }

--- a/nuxt-app/db/schema/index.ts
+++ b/nuxt-app/db/schema/index.ts
@@ -1,9 +1,10 @@
 import image from './image'
 import party from './party'
 import songs from './songs'
+import user from './user'
 
 /**
  * Register all schema components by exporting them from here.
  * (For compatibility with Drizzle `db-push`)
  */
-export { songs, image, party }
+export { songs, image, party, user }

--- a/nuxt-app/db/schema/user.ts
+++ b/nuxt-app/db/schema/user.ts
@@ -1,0 +1,12 @@
+import { mysqlTable, text } from 'drizzle-orm/mysql-core'
+import { nanoId } from '~/utils/nanoId/drizzle'
+
+/** Drizzle schema for Spotify user. */
+export default mysqlTable('user', {
+  id: nanoId('id').primaryKey(),
+  spotifyId: text('spotify_id').notNull(), // Unique is not yet implemented for Drizzle ORM!
+  name: text('name').notNull(),
+  email: text('e_mail').notNull(), // Unique is not yet implemented for Drizzle ORM!
+  accessToken: text('access_token').notNull(),
+  refreshToken: text('refresh_token').notNull(),
+})

--- a/nuxt-app/package-lock.json
+++ b/nuxt-app/package-lock.json
@@ -18,6 +18,7 @@
         "@vuepic/vue-datepicker": "^4.5.1",
         "drizzle-orm": "^0.26.5",
         "drizzle-zod": "^0.4.1",
+        "jsonwebtoken": "^9.0.0",
         "openai": "^3.2.1",
         "pusher": "^5.1.3",
         "pusher-js": "^8.0.2",
@@ -29,6 +30,7 @@
       },
       "devDependencies": {
         "@nuxtjs/eslint-config-typescript": "^12.0.0",
+        "@types/jsonwebtoken": "^9.0.2",
         "@types/node": "^18.15.11",
         "@types/spotify-web-api-node": "^5.0.7",
         "@typescript-eslint/parser": "^5.57.0",
@@ -4257,6 +4259,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -7473,6 +7484,11 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -9256,6 +9272,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/edge-runtime": {
       "version": "2.0.0",
@@ -13249,6 +13273,40 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
@@ -13416,8 +13474,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",

--- a/nuxt-app/package-lock.json
+++ b/nuxt-app/package-lock.json
@@ -21,6 +21,7 @@
         "openai": "^3.2.1",
         "pusher": "^5.1.3",
         "pusher-js": "^8.0.2",
+        "spotify-web-api-node": "^5.0.2",
         "superjson": "^1.12.2",
         "trpc-nuxt": "^0.8.0",
         "vuetify": "^3.2.2",
@@ -29,6 +30,7 @@
       "devDependencies": {
         "@nuxtjs/eslint-config-typescript": "^12.0.0",
         "@types/node": "^18.15.11",
+        "@types/spotify-web-api-node": "^5.0.7",
         "@typescript-eslint/parser": "^5.57.0",
         "drizzle-kit": "^0.18.1",
         "eslint": "^8.37.0",
@@ -4371,6 +4373,21 @@
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
+    "node_modules/@types/spotify-api": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@types/spotify-api/-/spotify-api-0.0.22.tgz",
+      "integrity": "sha512-oZLKiI6Fck/BGd0QdmIdJCY351xQfRkfpx2Q23jIntL3YQx85vScYuFJMK81/NoSK9m7HYOl2DW4A9WomDuJOA==",
+      "dev": true
+    },
+    "node_modules/@types/spotify-web-api-node": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/spotify-web-api-node/-/spotify-web-api-node-5.0.7.tgz",
+      "integrity": "sha512-8ajd4xS3+l4Zau1OyggPv7DjeSFEIGYvG5Q8PbbBMKiaRFD53IkcvU4Bx4Ijyzw+l+Kc09L5L+MXRj0wyVLx9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/spotify-api": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -7674,7 +7691,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -8166,6 +8182,11 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
     "node_modules/compress-commons": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.1.tgz",
@@ -8254,6 +8275,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "node_modules/copy-anything": {
       "version": "3.0.3",
@@ -8578,7 +8604,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -11120,6 +11145,11 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -11350,6 +11380,15 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
+      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -11491,8 +11530,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -11613,7 +11651,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
       "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -12007,7 +12044,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -12061,7 +12097,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -12416,8 +12451,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -14024,7 +14058,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14912,8 +14945,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mute-stream": {
       "version": "1.0.0",
@@ -15314,7 +15346,6 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -16768,7 +16799,6 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
       "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -16984,7 +17014,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -17576,7 +17605,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17631,7 +17659,6 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -17646,7 +17673,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -17657,8 +17683,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -17793,7 +17818,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -18063,6 +18087,14 @@
       "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
     },
+    "node_modules/spotify-web-api-node": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/spotify-web-api-node/-/spotify-web-api-node-5.0.2.tgz",
+      "integrity": "sha512-r82dRWU9PMimHvHEzL0DwEJrzFk+SMCVfq249SLt3I7EFez7R+jeoKQd+M1//QcnjqlXPs2am4DFsGk8/GCsrA==",
+      "dependencies": {
+        "superagent": "^6.1.0"
+      }
+    },
     "node_modules/ssri": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -18146,7 +18178,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -18325,6 +18356,39 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": ">= 7.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/superjson": {
@@ -19364,8 +19428,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
+    "@types/jsonwebtoken": "^9.0.2",
     "@types/node": "^18.15.11",
     "@types/spotify-web-api-node": "^5.0.7",
     "@typescript-eslint/parser": "^5.57.0",
@@ -52,6 +53,7 @@
     "@vuepic/vue-datepicker": "^4.5.1",
     "drizzle-orm": "^0.26.5",
     "drizzle-zod": "^0.4.1",
+    "jsonwebtoken": "^9.0.0",
     "openai": "^3.2.1",
     "pusher": "^5.1.3",
     "pusher-js": "^8.0.2",

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@types/node": "^18.15.11",
+    "@types/spotify-web-api-node": "^5.0.7",
     "@typescript-eslint/parser": "^5.57.0",
     "drizzle-kit": "^0.18.1",
     "eslint": "^8.37.0",
@@ -54,6 +55,7 @@
     "openai": "^3.2.1",
     "pusher": "^5.1.3",
     "pusher-js": "^8.0.2",
+    "spotify-web-api-node": "^5.0.2",
     "superjson": "^1.12.2",
     "trpc-nuxt": "^0.8.0",
     "vuetify": "^3.2.2",

--- a/nuxt-app/server/auth/index.ts
+++ b/nuxt-app/server/auth/index.ts
@@ -1,0 +1,49 @@
+// eslint-disable-next-line import/default
+import jwt from 'jsonwebtoken'
+import type { H3Event } from 'h3'
+import { User, userSchema } from '../utils/user'
+import { defaultCredentialsCookieSerializationOpts } from '~/utils/pkce'
+
+const expiresIn = '24h'
+
+export type Credentials = {
+  verifier: string // Used to verify user using Spotify's PKCE flow
+  jwt: string
+}
+
+/** Throw if env variable is missing. */
+const useJWTPrivateKey = () => {
+  const privateKey = process.env.JWT_PRIVATE_KEY
+  if (!privateKey) throw new Error('Missing JWT private key')
+  return privateKey
+}
+
+/** Sign JWT with public user data payload. */
+export const signJWT = (userData: User) => {
+  // eslint-disable-next-line import/no-named-as-default-member
+  return jwt.sign(userData, useJWTPrivateKey(), { expiresIn })
+}
+
+/**
+ * Verify JWT and return user data payload.
+ *
+ * Returns `undefined` if JWT could not be verified.
+ */
+export const verifyJWT = (token: string) => {
+  try {
+    // eslint-disable-next-line import/no-named-as-default-member
+    const userData = jwt.verify(token, useJWTPrivateKey())
+    return userSchema.parse(userData)
+  } catch (_) {
+    return undefined
+  }
+}
+
+/**
+ * Set JWT as session cookie using Nitro's `setCookie`.
+ *
+ * Uses sane defaults for serialization options.
+ */
+export const setJWTCookie = (event: H3Event, token: string) => {
+  setCookie(event, 'jwt', token, defaultCredentialsCookieSerializationOpts)
+}

--- a/nuxt-app/server/trpc/context.ts
+++ b/nuxt-app/server/trpc/context.ts
@@ -1,7 +1,7 @@
 import { inferAsyncReturnType } from '@trpc/server'
 import type { H3Event } from 'h3'
 import { parse } from 'cookie'
-import { Credentials } from '../utils/pkce'
+import { Credentials } from '../auth'
 
 /**
  * Create context for all incoming request
@@ -20,8 +20,7 @@ export const createContext = (event: H3Event) => {
     const cookies = parse(rawCookies)
     credentials = {
       verifier: cookies.code_verifier,
-      accessToken: cookies.access_token,
-      refreshToken: cookies.refresh_token,
+      jwt: cookies.jwt,
     }
   }
 

--- a/nuxt-app/server/trpc/middleware/auth.ts
+++ b/nuxt-app/server/trpc/middleware/auth.ts
@@ -136,7 +136,7 @@ const isAuthed = middleware(async ({ next, ctx }) => {
   }
 
   // Pass user info into context (for private procedures to use)
-  return next({ ctx: { user } })
+  return next({ ctx: { user, credentials: { ...ctx.credentials, accessToken, refreshToken } } })
 })
 
 /**

--- a/nuxt-app/server/trpc/middleware/auth.ts
+++ b/nuxt-app/server/trpc/middleware/auth.ts
@@ -1,52 +1,8 @@
 import { TRPCError } from '@trpc/server'
-import { z } from 'zod'
 import type { H3Event } from 'h3'
 import { middleware, publicProcedure } from '../trpc'
-import { fetchCredentials, getAuthHeader } from '~/server/utils/pkce'
-import tsFetch from '~/utils/tsFetch'
-
-/**
- * User data as returned by the Spotify API.
- *
- * Reference:
- * https://developer.spotify.com/documentation/web-api/reference/get-current-users-profile
- */
-const spotifyUserSchema = z.object({
-  country: z.string(),
-  display_name: z.string(),
-  email: z.string(),
-  explicit_content: z.object({
-    filter_enabled: z.boolean(),
-    filter_locked: z.boolean(),
-  }),
-  external_urls: z.object({
-    spotify: z.string(),
-  }),
-  followers: z.object({
-    href: z.string().nullable(),
-    total: z.number(),
-  }),
-  href: z.string(),
-  id: z.string(),
-  images: z
-    .object({
-      url: z.string(),
-      height: z.number().nullable(),
-      width: z.number().nullable(),
-    })
-    .array(),
-  product: z.string(),
-  type: z.string(),
-  uri: z.string(),
-})
-
-/**
- * Unauthorized error as returned by the Spotify API.
- *
- * Reference:
- * https://developer.spotify.com/documentation/web-api/reference/get-current-users-profile
- */
-const spotifyUserUnauthorizedSchema = z.object({ error: z.object({ status: z.number(), message: z.string() }) })
+import { fetchCredentials } from '~/server/utils/pkce'
+import { SpotifyUser, fetchUserDataFromSpotify, getUserDataFromDB } from '~/server/utils/user'
 
 /**
  * Helper function to update refresh and access token.
@@ -62,15 +18,6 @@ const updateCredentials = async (refreshToken: string, event: H3Event) => {
     accessToken: res.access_token,
     refreshToken: res.refresh_token,
   }
-}
-
-/** Fetch user data from Spotify API. */
-const fetchUserData = async (accessToken: string) => {
-  return await tsFetch(
-    'https://api.spotify.com/v1/me',
-    { 200: spotifyUserSchema, 401: spotifyUserUnauthorizedSchema },
-    { headers: getAuthHeader(accessToken) }
-  )
 }
 
 /**
@@ -90,7 +37,7 @@ const isAuthed = middleware(async ({ next, ctx }) => {
   // Throw if both, access and refresh token, are missing
   if (!accessToken && !refreshToken) throw unauthorizedError
 
-  let user: z.infer<typeof spotifyUserSchema>
+  let user: SpotifyUser
 
   // Update credentials (incl. cookies) using refresh token if no access token exists
   // (Throw if access token can't be fetched)
@@ -107,12 +54,12 @@ const isAuthed = middleware(async ({ next, ctx }) => {
 
   // Try fetching user data using access token
   // (Throw on any other status codes than 200 and 401)
-  const userRes = await fetchUserData(accessToken).catch(() => {
+  const userRes = await fetchUserDataFromSpotify(accessToken).catch(() => {
     throw userDataError
   })
 
   // Check if user data was returned (200)
-  if ('id' in userRes) {
+  if (userRes) {
     user = userRes
     // If user was unauthorized (401), access token might be expired or invalid
   } else {
@@ -123,11 +70,11 @@ const isAuthed = middleware(async ({ next, ctx }) => {
     }))
     // Try fetching user data again, now that all tokens are up-to date
     // (Throw on any other status codes than 200 and 401)
-    const userRes = await fetchUserData(accessToken).catch(() => {
+    const userRes = await fetchUserDataFromSpotify(accessToken).catch(() => {
       throw userDataError
     })
     // Check if user data was returned (200)
-    if ('id' in userRes) {
+    if (userRes) {
       user = userRes
       // Otherwise throw final unauthorized error
     } else {
@@ -135,8 +82,13 @@ const isAuthed = middleware(async ({ next, ctx }) => {
     }
   }
 
+  // Get user data from database
+  const userData = await getUserDataFromDB(user.spotifyId)
+  // Throw if user does not exist in database
+  if (!userData) throw unauthorizedError
+
   // Pass user info into context (for private procedures to use)
-  return next({ ctx: { user, credentials: { ...ctx.credentials, accessToken, refreshToken } } })
+  return next({ ctx: { user: userData, credentials: { ...ctx.credentials, accessToken, refreshToken } } })
 })
 
 /**

--- a/nuxt-app/server/trpc/middleware/auth.ts
+++ b/nuxt-app/server/trpc/middleware/auth.ts
@@ -1,94 +1,31 @@
 import { TRPCError } from '@trpc/server'
-import type { H3Event } from 'h3'
 import { middleware, publicProcedure } from '../trpc'
-import { fetchCredentials } from '~/server/utils/pkce'
-import { SpotifyUser, fetchUserDataFromSpotify, getUserDataFromDB } from '~/server/utils/user'
-
-/**
- * Helper function to update refresh and access token.
- *
- * - Fetches new credentials using refresh token.
- * - Sets cookies for new credentials using Nitro.
- */
-const updateCredentials = async (refreshToken: string, event: H3Event) => {
-  const res = await fetchCredentials({ refreshToken })
-  setCookie(event, 'access_token', res.access_token)
-  setCookie(event, 'refresh_token', res.refresh_token)
-  return {
-    accessToken: res.access_token,
-    refreshToken: res.refresh_token,
-  }
-}
+import { verifyJWT } from '~/server/auth'
 
 /**
  * Authentication middleware.
  *
- * - Checks that provided credentials can be used to fetch user data from Spotify API
+ * - Verifies JWT containing user data
  * - Passes user data into tRPC context
  *
  * Reference:
  * https://trpc.io/docs/v9/middlewares
  */
-const isAuthed = middleware(async ({ next, ctx }) => {
-  let { accessToken, refreshToken } = ctx.credentials
-  const { event } = ctx
+const isAuthed = middleware(({ next, ctx }) => {
+  const { jwt } = ctx.credentials
+
   const unauthorizedError = new TRPCError({ code: 'UNAUTHORIZED' })
 
-  // Throw if both, access and refresh token, are missing
-  if (!accessToken && !refreshToken) throw unauthorizedError
+  // Throw if JWT is missing
+  if (!jwt) throw unauthorizedError
 
-  let user: SpotifyUser
+  const user = verifyJWT(jwt)
 
-  // Update credentials (incl. cookies) using refresh token if no access token exists
-  // (Throw if access token can't be fetched)
-  if (!accessToken && refreshToken) {
-    ;({ accessToken, refreshToken } = await updateCredentials(refreshToken, event).catch(() => {
-      throw unauthorizedError
-    }))
-  }
-
-  // Access and refresh tokens should now be set, but access token might be expired or invalid.
-  if (!accessToken || !refreshToken) throw unauthorizedError
-
-  const userDataError = new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Could not fetch user data!' })
-
-  // Try fetching user data using access token
-  // (Throw on any other status codes than 200 and 401)
-  const userRes = await fetchUserDataFromSpotify(accessToken).catch(() => {
-    throw userDataError
-  })
-
-  // Check if user data was returned (200)
-  if (userRes) {
-    user = userRes
-    // If user was unauthorized (401), access token might be expired or invalid
-  } else {
-    // Update credentials (incl. cookies) using refresh token if no access token exists
-    // (Throw if access token can't be fetched)
-    ;({ accessToken, refreshToken } = await updateCredentials(refreshToken, event).catch(() => {
-      throw unauthorizedError
-    }))
-    // Try fetching user data again, now that all tokens are up-to date
-    // (Throw on any other status codes than 200 and 401)
-    const userRes = await fetchUserDataFromSpotify(accessToken).catch(() => {
-      throw userDataError
-    })
-    // Check if user data was returned (200)
-    if (userRes) {
-      user = userRes
-      // Otherwise throw final unauthorized error
-    } else {
-      throw unauthorizedError
-    }
-  }
-
-  // Get user data from database
-  const userData = await getUserDataFromDB(user.spotifyId)
-  // Throw if user does not exist in database
-  if (!userData) throw unauthorizedError
+  // Throw if JWT could not be verified
+  if (!user) throw unauthorizedError
 
   // Pass user info into context (for private procedures to use)
-  return next({ ctx: { user: userData, credentials: { ...ctx.credentials, accessToken, refreshToken } } })
+  return next({ ctx: { user } })
 })
 
 /**

--- a/nuxt-app/server/trpc/middleware/spotify.ts
+++ b/nuxt-app/server/trpc/middleware/spotify.ts
@@ -1,0 +1,28 @@
+import SpotifyWebApi from 'spotify-web-api-node'
+import { TRPCError } from '@trpc/server'
+import { privateProcedure } from './auth'
+import { SpotifyServerClient } from '~/server/utils/spotifyServerClient'
+
+const { env } = process
+
+/** Middleware for making requests to the Spotify-API involving user data. */
+export const spotifyUserProcedure = privateProcedure.use(({ next, ctx }) => {
+  const spotifyUserAPI = new SpotifyWebApi()
+  spotifyUserAPI.setAccessToken(ctx.credentials.accessToken)
+
+  return next({ ctx: { spotifyClientAPI: spotifyUserAPI } })
+})
+
+/** Middleware for making requests to the Spotify-API not involving user data. */
+export const spotifyServerProcedure = privateProcedure.use(async ({ next }) => {
+  const clientId = env.SPOTIFY_CLIENT_ID
+  const clientSecret = env.SPOTIFY_CLIENT_SECRET
+
+  if (!clientId || !clientSecret)
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Missing server-side Spotify credentials' })
+
+  const spotifyServerClient = await SpotifyServerClient.init(clientId, clientSecret)
+  const spotifyServerAPI = await spotifyServerClient.useWebAPI()
+
+  return next({ ctx: { spotifyServerAPI } })
+})

--- a/nuxt-app/server/trpc/middleware/spotify.ts
+++ b/nuxt-app/server/trpc/middleware/spotify.ts
@@ -2,13 +2,21 @@ import SpotifyWebApi from 'spotify-web-api-node'
 import { TRPCError } from '@trpc/server'
 import { privateProcedure } from './auth'
 import { SpotifyServerClient } from '~/server/utils/spotifyServerClient'
+import { getPrivateUserDataFromDB } from '~~/server/utils/user'
 
 const { env } = process
 
 /** Middleware for making requests to the Spotify-API involving user data. */
-export const spotifyUserProcedure = privateProcedure.use(({ next, ctx }) => {
+export const spotifyUserProcedure = privateProcedure.use(async ({ next, ctx }) => {
+  // Get the user's Spotify credentials from DB
+  const user = await getPrivateUserDataFromDB(ctx.user.id)
+  if (!user) throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'User not found in database' })
+
+  // Create a new Spotify-API client with the user's credentials
   const spotifyUserAPI = new SpotifyWebApi()
-  spotifyUserAPI.setAccessToken(ctx.credentials.accessToken)
+  // TODO: Check if tokens are valid, refresh if needed and update DB
+  spotifyUserAPI.setAccessToken(user.accessToken)
+  spotifyUserAPI.setRefreshToken(user.refreshToken)
 
   return next({ ctx: { spotifyClientAPI: spotifyUserAPI } })
 })
@@ -21,6 +29,7 @@ export const spotifyServerProcedure = privateProcedure.use(async ({ next }) => {
   if (!clientId || !clientSecret)
     throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Missing server-side Spotify credentials' })
 
+  // Create a new Spotify-API client with server-side credentials
   const spotifyServerClient = await SpotifyServerClient.init(clientId, clientSecret)
   const spotifyServerAPI = await spotifyServerClient.useWebAPI()
 

--- a/nuxt-app/server/trpc/routers/index.ts
+++ b/nuxt-app/server/trpc/routers/index.ts
@@ -3,6 +3,7 @@ import { songsRouter } from './songs'
 import { authRouter } from './auth'
 import { partyRouter } from './party'
 import { sessionRouter } from './session'
+import { spotifyRouter } from './spotify'
 
 /** Bundle sub-routers for entire application. */
 export const appRouter = router({
@@ -10,6 +11,7 @@ export const appRouter = router({
   songs: songsRouter,
   party: partyRouter,
   session: sessionRouter,
+  spotify: spotifyRouter,
 })
 
 /** API type definition. */

--- a/nuxt-app/server/trpc/routers/spotify.ts
+++ b/nuxt-app/server/trpc/routers/spotify.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+import { spotifyUserProcedure, spotifyServerProcedure } from '../middleware/spotify'
+import { router } from '../trpc'
+
+const trackQuerySchema = z.string()
+
+const createPlaylistSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+})
+
+export const spotifyRouter = router({
+  /**
+   * Get Spotify track Id for every track query (if result was found.)
+   *
+   * Spotify search does allow for explicit filters like `'track:...,artist:...'`,
+   * but using a simple query string containing the track name and author is often enough.
+   * This also allows searching for non precise ChatGPT outputs like `'Thriller by Micheal Jackson'`.
+   *
+   * Reference:
+   * https://developer.spotify.com/documentation/web-api/reference/search
+   */
+  searchTracks: spotifyServerProcedure.input(trackQuerySchema.array()).query(async ({ input, ctx }) => {
+    const res = await Promise.all(input.map((query) => ctx.spotifyServerAPI.searchTracks(query, { limit: 1 })))
+    const trackIds = res
+      .map((rs) => {
+        return rs.body.tracks?.items[0]?.id
+      })
+      .filter((id): id is string => !!id)
+    return trackIds
+  }),
+  /** Get single track using its Spotify Id (for debugging purposes only). */
+  getTrackById: spotifyServerProcedure.input(z.string()).query(async ({ input, ctx }) => {
+    return (await ctx.spotifyServerAPI.getTrack(input)).body
+  }),
+  /**
+   * Create private collaborative playlist as the main party playlist.
+   *
+   * Reference:
+   * https://developer.spotify.com/documentation/web-api/reference/create-playlist
+   */
+  createPartyPlaylist: spotifyUserProcedure.input(createPlaylistSchema).mutation(async ({ input, ctx }) => {
+    const { name, description } = input
+    return (await ctx.spotifyClientAPI.createPlaylist(name, { description, collaborative: true, public: false })).body
+  }),
+})

--- a/nuxt-app/server/utils/crypto.ts
+++ b/nuxt-app/server/utils/crypto.ts
@@ -1,0 +1,45 @@
+import crypto from 'crypto'
+
+const METHOD = 'aes-256-cbc'
+
+// String from env variables
+type EnvString = string | undefined
+
+/**
+ * Generate key and initialization vector for AES-256-CBC cipher.
+ *
+ * Reference:
+ * https://dev.to/jobizil/encrypt-and-decrypt-data-in-nodejs-using-aes-256-cbc-2l6d
+ */
+const genSecrets = (key: EnvString, iv: EnvString) => {
+  if (!key || !iv) throw new Error('missing encryption secrets')
+  return {
+    key: crypto.createHash('sha512').update(key).digest('hex').substring(0, 32),
+    iv: crypto.createHash('sha512').update(iv).digest('hex').substring(0, 16),
+  }
+}
+
+/**
+ * Encrypt data using AES-256-CBC cipher with variable key and initialization vector.
+ *
+ * Reference:
+ * https://dev.to/jobizil/encrypt-and-decrypt-data-in-nodejs-using-aes-256-cbc-2l6d
+ */
+export const encryptData = (data: string, key: EnvString, iv: EnvString) => {
+  const { key: secretKey, iv: initVector } = genSecrets(key, iv)
+  const cipher = crypto.createCipheriv(METHOD, secretKey, initVector)
+  return Buffer.from(cipher.update(data, 'utf8', 'hex') + cipher.final('hex')).toString('base64')
+}
+
+/**
+ * Decrypt data using AES-256-CBC cipher with variable key and initialization vector.
+ *
+ * Reference:
+ * https://dev.to/jobizil/encrypt-and-decrypt-data-in-nodejs-using-aes-256-cbc-2l6d
+ */
+export const decryptData = (data: string, key: EnvString, iv: EnvString) => {
+  const { key: secretKey, iv: initVector } = genSecrets(key, iv)
+  const decipher = crypto.createDecipheriv(METHOD, secretKey, initVector)
+  const buff = Buffer.from(data, 'base64')
+  return decipher.update(buff.toString('utf8'), 'hex', 'utf8') + decipher.final('utf8')
+}

--- a/nuxt-app/server/utils/spotifyServerClient.ts
+++ b/nuxt-app/server/utils/spotifyServerClient.ts
@@ -1,0 +1,85 @@
+import SpotifyWebApi from 'spotify-web-api-node'
+import z from 'zod'
+import tsFetch from '~/utils/tsFetch'
+
+const spotifyClientCredentialsResponseSchema = z.object({
+  access_token: z.string(),
+  token_type: z.string(),
+  expires_in: z.number(),
+})
+
+/**
+ * Class for server-side interaction with Spotify-Web-API
+ *
+ * Uses async init factory function.
+ *
+ * Reference:
+ * https://dev.to/somedood/the-proper-way-to-write-async-constructors-in-javascript-1o8c
+ */
+export class SpotifyServerClient {
+  clientId: string
+  clientSecret: string
+  accessToken: string
+  accessTokenExpiry: Date
+
+  private constructor(clientId: string, clientSecret: string, accessToken: string, accessTokenExpiry: Date) {
+    this.clientId = clientId
+    this.clientSecret = clientSecret
+    this.accessToken = accessToken
+    this.accessTokenExpiry = accessTokenExpiry
+  }
+
+  /**
+   * Fetch access token from Spotify-Web-API and calculate its expiry date.
+   *
+   * Uses Client Credentials flow for server-side usage of Spotify-API.
+   *
+   * Reference:
+   * https://developer.spotify.com/documentation/web-api/tutorials/client-credentials-flow
+   */
+  private static async fetchAccessToken(clientId: string, clientSecret: string, expiryBufferSeconds = 600) {
+    const headers = {
+      'Authorization': `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    }
+
+    const searchParams = new URLSearchParams({ grant_type: 'client_credentials' })
+
+    const { access_token: accessToken, expires_in: expiresIn } = await tsFetch(
+      'https://accounts.spotify.com/api/token',
+      { 200: spotifyClientCredentialsResponseSchema },
+      { method: 'post', headers, body: searchParams }
+    )
+
+    const tokenExpiry = new Date()
+    tokenExpiry.setSeconds(tokenExpiry.getSeconds() + expiresIn - expiryBufferSeconds)
+
+    return { accessToken, tokenExpiry }
+  }
+
+  /** Initialize Spotify-Server-Client with access token. */
+  static async init(clientId: string, clientSecret: string) {
+    const { accessToken, tokenExpiry } = await this.fetchAccessToken(clientId, clientSecret)
+
+    return new SpotifyServerClient(clientId, clientSecret, accessToken, tokenExpiry)
+  }
+
+  /** Check if access token is expired. */
+  private tokenExpired() {
+    return new Date() > this.accessTokenExpiry
+  }
+
+  /** Return Spotify Web-API-Client with valid server-side access token. */
+  async useWebAPI() {
+    if (this.tokenExpired()) {
+      const { accessToken, tokenExpiry } = await SpotifyServerClient.fetchAccessToken(this.clientId, this.clientSecret)
+      this.accessToken = accessToken
+      this.accessTokenExpiry = tokenExpiry
+      if (this.tokenExpired()) throw new Error('Access token expired directly after refreshing')
+    }
+
+    const spotifyAPI = new SpotifyWebApi()
+    spotifyAPI.setAccessToken(this.accessToken)
+    return spotifyAPI
+  }
+}

--- a/nuxt-app/server/utils/user.ts
+++ b/nuxt-app/server/utils/user.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod'
+import { InferModel, eq } from 'drizzle-orm'
+import { decryptData, encryptData } from './crypto'
+import tsFetch from '~/utils/tsFetch'
+import { getAuthHeader } from '~/server/utils/pkce'
+import user from '~/db/schema/user'
+import { db } from '~/db'
+import { genNanoId } from '~/utils/nanoId'
+
+export type User = InferModel<typeof user>
+export type SpotifyUser = Omit<User, 'id' | 'accessToken' | 'refreshToken'>
+
+/**
+ * User data as returned by the Spotify API.
+ *
+ * Reference:
+ * https://developer.spotify.com/documentation/web-api/reference/get-current-users-profile
+ */
+export const spotifyUserSchema = z.object({
+  country: z.string(),
+  display_name: z.string(),
+  email: z.string(),
+  explicit_content: z.object({
+    filter_enabled: z.boolean(),
+    filter_locked: z.boolean(),
+  }),
+  external_urls: z.object({
+    spotify: z.string(),
+  }),
+  followers: z.object({
+    href: z.string().nullable(),
+    total: z.number(),
+  }),
+  href: z.string(),
+  id: z.string(),
+  images: z
+    .object({
+      url: z.string(),
+      height: z.number().nullable(),
+      width: z.number().nullable(),
+    })
+    .array(),
+  product: z.string(),
+  type: z.string(),
+  uri: z.string(),
+})
+
+/**
+ * Unauthorized error as returned by the Spotify API.
+ *
+ * Reference:
+ * https://developer.spotify.com/documentation/web-api/reference/get-current-users-profile
+ */
+export const spotifyUserUnauthorizedSchema = z.object({ error: z.object({ status: z.number(), message: z.string() }) })
+
+/** Fetch user data from Spotify API. */
+export const fetchUserDataFromSpotify = async (accessToken: string): Promise<SpotifyUser | undefined> => {
+  const spotifyUser = await tsFetch(
+    'https://api.spotify.com/v1/me',
+    { 200: spotifyUserSchema, 401: spotifyUserUnauthorizedSchema },
+    { headers: getAuthHeader(accessToken) }
+  )
+
+  if (!('id' in spotifyUser)) return undefined
+
+  return {
+    spotifyId: spotifyUser.id,
+    name: spotifyUser.display_name,
+    email: spotifyUser.email,
+  }
+}
+
+const { env } = process
+
+/** Encrypt the user's Spotify credentials with AES. */
+export const encryptUserCredentials = (accessToken: string, refreshToken: string) => {
+  return {
+    accessToken: encryptData(accessToken, env.CRYPTO_USER_KEY, env.CRYPTO_USER_IV),
+    refreshToken: encryptData(refreshToken, env.CRYPTO_USER_KEY, env.CRYPTO_USER_IV),
+  }
+}
+
+/** Decrypt the user's Spotify credentials with AES. */
+export const decryptUserCredentials = (encryptedAccessToken: string, encryptedRefreshToken: string) => {
+  return {
+    accessToken: decryptData(encryptedAccessToken, env.CRYPTO_USER_KEY, env.CRYPTO_USER_IV),
+    refreshToken: decryptData(encryptedRefreshToken, env.CRYPTO_USER_KEY, env.CRYPTO_USER_IV),
+  }
+}
+
+/**
+ * Get user data.
+ *
+ * Get user data without credentials (should be used in most cases).
+ */
+export const getUserDataFromDB = async (spotifyUserId: string) => {
+  return (await db.select().from(user).where(eq(user.spotifyId, spotifyUserId)))[0]
+}
+
+/**
+ * Update credentials for user in database.
+ *
+ * Encrypts access token and refresh token.
+ */
+export const updateUserCredentials = async (spotifyUserId: string, accessToken: string, refreshToken: string) => {
+  const encryptedCredentials = encryptUserCredentials(accessToken, refreshToken)
+  await db.update(user).set(encryptedCredentials).where(eq(user.spotifyId, spotifyUserId))
+  return getUserDataFromDB(spotifyUserId)
+}
+
+/**
+ * Insert new user into database.
+ *
+ * Encrypts access token and refresh token.
+ */
+export const upsertUser = async (userData: SpotifyUser, accessToken: string, refreshToken: string) => {
+  const existingUser = (await db.select().from(user).where(eq(user.spotifyId, userData.spotifyId)))[0]
+  if (existingUser) {
+    return updateUserCredentials(existingUser.spotifyId, accessToken, refreshToken)
+  } else {
+    const encryptedCredentials = encryptUserCredentials(accessToken, refreshToken)
+    await db.insert(user).values({ ...userData, ...encryptedCredentials, id: genNanoId() })
+    return await getUserDataFromDB(userData.spotifyId)
+  }
+}


### PR DESCRIPTION
Changes:
- Added basic setup for Spotify-Web-API
- Updated user authentication:
    - Spotify credentials are encryped and stored in DB to allow backend to update the playlist, even if host is not connected
    - (Unfortunately, this can't be done through collaborative playlists since Spotify-API doesn't allow editing them)
    - User authentication now uses a custom JWT in order to aviod conflicts due to refresh token rotation when using Spotify credentials in the backend