### PR TITLE
Update to explicitly load initial session messages and playlist

### DIFF
--- a/nuxt-app/pages/party/session.vue
+++ b/nuxt-app/pages/party/session.vue
@@ -31,7 +31,7 @@
   const tabs = ['suggestion', 'playlist']
   const suggestion = ref('')
 
-  const partySession = usePartySession(user.name, user.id)
+  const partySession = await usePartySession(user.name, user.id)
 
   const scrollToBottom = () => {
     const listContainer = document.getElementById('listContainer')

--- a/nuxt-app/server/trpc/routers/session.ts
+++ b/nuxt-app/server/trpc/routers/session.ts
@@ -69,7 +69,7 @@ const updatePlaylist = async (sessionMessages: FullMessage[], party: Party, even
 
     // Publish new playlist
     // Publish without data, since size of playlist data regularly exceeds Pusher's maximum playlist size (let clients fetch playlist themselves)
-    partySession.publishPlaylist(playlistId)
+    partySession.publishPlaylist()
   }
 }
 
@@ -103,4 +103,11 @@ export const sessionRouter = router({
       if (userMessages.length % openAIClient.opts.promptMessageBuffer === 0)
         await updatePlaylist(sessionMessages, ctx.party, ctx.event)
     }),
+  /** Get all user messages for party session. */
+  getMessages: sessionProcedure.query(async ({ input }) => {
+    const { session } = input
+    const partySession = new PartySession(session.sessionCode)
+    const messages = (await partySession.getMessages()) ?? []
+    return partySession.parseFullMessagesForUsers(messages)
+  }),
 })

--- a/nuxt-app/server/trpc/routers/spotify.ts
+++ b/nuxt-app/server/trpc/routers/spotify.ts
@@ -111,8 +111,9 @@ export const spotifyRouter = router({
       }
     }),
   /** Get single playlist by Id. */
-  getPlaylist: spotifySessionUserProcedure.input(z.object({ playlistId: z.string() })).query(async ({ ctx, input }) => {
-    const playlist = (await ctx.spotifyUserAPI.getPlaylist(input.playlistId)).body
+  getPlaylist: spotifySessionUserProcedure.query(async ({ ctx }) => {
+    const { playlistId } = ctx.party
+    const playlist = (await ctx.spotifyUserAPI.getPlaylist(playlistId)).body
     // Keep data to a minimum
     return {
       id: playlist.id,

--- a/nuxt-app/server/utils/partySession.ts
+++ b/nuxt-app/server/utils/partySession.ts
@@ -111,7 +111,7 @@ export class PartySession {
    * - https://github.com/pusher/pusher-http-node#publishing-events
    * - https://support.pusher.com/hc/en-us/articles/4412243423761-What-Is-The-Message-Size-Limit-When-Publishing-an-Event-in-Channels-
    */
-  public async publishPlaylist(playlistId: string) {
-    return await this.pusher.trigger(presenceCacheChannel(this.sessionCode), events.playlist, playlistId)
+  public async publishPlaylist() {
+    return await this.pusher.trigger(presenceCacheChannel(this.sessionCode), events.playlist, null)
   }
 }

--- a/nuxt-app/utils/partySession.ts
+++ b/nuxt-app/utils/partySession.ts
@@ -88,7 +88,7 @@ export class PartySession {
   }
 
   /** Set callback for new playlist on the party session channel. */
-  public onPlaylist(callback: (playlistId: string) => void) {
+  public onPlaylist(callback: () => void) {
     this.partyChannel.bind(events.playlist, callback)
   }
 


### PR DESCRIPTION
Updated `usePartySession` composable to load initial messages and playlist on creation.

Frontend TODO: `scrollToBottom` when rendering initial messages